### PR TITLE
Sandbox security

### DIFF
--- a/pgbot/sandbox.py
+++ b/pgbot/sandbox.py
@@ -218,7 +218,8 @@ async def exec_sandbox(code: str, timeout=5, max_memory=2 ** 28):
     allowed_globals["output"] = output
 
     for illegal_patterns in ["__subclasses__", "__loader__", "__bases__", "__code__",
-                             "__getattribute__", "__setattr__", "__delattr_", "mro"]:
+                             "__getattribute__", "__setattr__", "__delattr_", "mro",
+                             "__class__", "__dict__"]:
         if illegal_patterns in code:
             output.exc = PgExecBot("Suspicious Pattern")
             return output


### PR DESCRIPTION
Add `__class__` and `__dict__` to illegal patterns.