### PR TITLE
Add field support for pg!emsudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The [Pygame Community Discord](https://discord.gg/kD2Qq9tbKm) bot
 ## Admin commands
 - `pg!eval {code}` evaluate a one line code (The code shouldn't be inside a code block) without any container/limitation, helpful for debugging.
 - `pg!sudo {message}` speaks back the message as if the bot's the one who's talking.
-- `pg!emsudo {title}, {body}, {hex}, [image_url]` `pg!emsudo {title}, {body}` sends an embed back with the arguments such as the hex color, title, and the body content.
+- `pg!emsudo {title}, {body}, {hex}, [image_url] [fields]` `pg!emsudo {title}, {body}` sends an embed back with the arguments such as the hex color, title, and the body content. The fields argument must be a list of strings with the following format: `<Field|Title|desc.[|isinline=False]>`.
 - `pg!sudo_edit {message_id} {message}` edits a message that was sent from the bot by the message ID.
 - `pg!emsudo_edit {message_id}, {title}, {body}, {hex}, [image_url]` `pg!emsudo-edit {message_id}, {title}, {body}` edits the embed of a message that was sent from the bot by the message ID.
 - `pg!archive {origin_channel} {quantity} {destination_channel}` Gets `quantity` amount of the latest messages from `origin_channel` and resends it/"archives" it with the messages' details (Such as the author and their ID, attachments, embeds).

--- a/pgbot/admin_commands.py
+++ b/pgbot/admin_commands.py
@@ -132,12 +132,32 @@ class AdminCommand(user_commands.UserCommand):
                 args[2]
             )
         elif len(args) == 4:
+            if isinstance(args[3], list):
+                fields = util.get_embed_fields(args[3])
+                await util.send_embed(
+                    self.invoke_msg.channel,
+                    args[0],
+                    args[1],
+                    args[2],
+                    fields=fields
+                )
+            else:
+                await util.send_embed(
+                    self.invoke_msg.channel,
+                    args[0],
+                    args[1],
+                    args[2],
+                    args[3]
+                )
+        elif len(args) == 5:
+            fields = util.get_embed_fields(args[3])
             await util.send_embed(
                 self.invoke_msg.channel,
                 args[0],
                 args[1],
                 args[2],
-                args[3]
+                args[3],
+                fields=fields
             )
         else:
             await util.edit_embed(

--- a/pgbot/util.py
+++ b/pgbot/util.py
@@ -1,6 +1,5 @@
 import asyncio
-import sys
-import time
+import re
 
 import discord
 
@@ -74,6 +73,29 @@ def filter_id(mention: str):
     return int(mention)
 
 
+def get_embed_fields(messages):
+    # syntax: <Field|Title|desc.[|inline=False]>
+    field_regex = r"(<Field\|.*\|.*(\|True|\|False|)>)"
+    field_datas = []
+
+    for message in messages:
+        field_list = re.split(field_regex, message)
+        for field in field_list:
+            if field:
+                field = field[1:-1]
+                field_data = field.split("|")
+
+                if len(field_data) not in [3, 4]:
+                    continue
+                if len(field_data) == 3:
+                    field_data.append("")
+
+                field_data[3] = True if field_data[3] == "True" else False
+
+                field_datas.append(field_data[1:])
+
+    return field_datas
+
 async def edit_embed(message, title, description, color=0xFFFFAA, url_image=None):
     """
     Edits the embed of a message with a much more tight function
@@ -85,13 +107,16 @@ async def edit_embed(message, title, description, color=0xFFFFAA, url_image=None
     return await message.edit(embed=embed)
 
 
-async def send_embed(channel, title, description, color=0xFFFFAA, url_image=None):
+async def send_embed(channel, title, description, color=0xFFFFAA, url_image=None, fields=[]):
     """
     Sends an embed with a much more tight function
     """
     embed = discord.Embed(title=title, description=description, color=color)
     if url_image:
         embed.set_image(url=url_image)
+
+    for field in fields:
+        embed.add_field(name=field[0], value=field[1], inline=field[3])
 
     return await channel.send(embed=embed)
 


### PR DESCRIPTION
Syntax:

`<Field|Title|desc.[|isinline]>`
The `isinline` is optional and defaults to False

```py
pg!emsudo "Embed title", "Message", 0xff0000 ["<Field|Title1|A description|True>", "<Field|Title2|A description|True>", "<Field|Title3|A description|True>"]
```