### PR TITLE
Embed revamp

### DIFF
--- a/pgbot/admin_commands.py
+++ b/pgbot/admin_commands.py
@@ -1,9 +1,9 @@
 import os
 import sys
 import time
-
+from datetime import datetime
+from discord.embeds import EmptyEmbed
 import psutil
-
 from . import user_commands, common, util
 
 process = psutil.Process(os.getpid())
@@ -109,7 +109,7 @@ class AdminCommand(user_commands.UserCommand):
 
     async def cmd_emsudo(self):
         """
-        Implement pg!emsudo, for admins to send images via the bot
+        Implement pg!emsudo, for admins to send embeds via the bot
         """
         args = eval(self.string)
 
@@ -173,7 +173,7 @@ class AdminCommand(user_commands.UserCommand):
 
     async def cmd_emsudo_edit(self):
         """
-        Implement pg!emsudo_edit, for admins to edit images via the bot
+        Implement pg!emsudo_edit, for admins to edit embeds via the bot
         """
         args = eval(self.string)
         edit_msg = await self.invoke_msg.channel.fetch_message(
@@ -235,6 +235,272 @@ class AdminCommand(user_commands.UserCommand):
             )
             return
 
+        await self.response_msg.delete()
+        await self.invoke_msg.delete()
+
+    async def cmd_emsudo_2(self):
+        """
+        Implement pg!emsudo_2, for admins to send embeds via the bot
+        """
+
+        util_send_embed_args = dict(
+            embed_type="rich", author_name=EmptyEmbed, author_name_url=EmptyEmbed, author_icon_url=EmptyEmbed,
+            title=EmptyEmbed, url=EmptyEmbed, thumbnail_url=EmptyEmbed, description=EmptyEmbed, image_url=EmptyEmbed,
+            color=0xFFFFAA, fields=(), footer_text=EmptyEmbed, footer_icon_url=EmptyEmbed, timestamp=None
+        )
+
+        args = eval(self.string)
+
+        if isinstance(args, dict):
+            await util.send_embed_from_dict(self.invoke_msg.channel, args)
+            await self.response_msg.delete()
+            await self.invoke_msg.delete()
+            return
+
+        arg_count = len(args)
+
+        if arg_count > 0:
+            if isinstance(args[0], (tuple, list)):
+                if len(args[0]) == 3:
+                    util_send_embed_args.update(
+                        author_name=args[0][0],
+                        author_name_url=args[0][1],
+                        author_icon_url=args[0][2],
+                    )
+                elif len(args[0]) == 2:
+                    util_send_embed_args.update(
+                        author_name=args[0][0],
+                        author_name_url=args[0][1],
+                    )
+                elif len(args[0]) == 1:
+                    util_send_embed_args.update(
+                        author_name=args[0][0],
+                    )
+            
+            else:
+                util_send_embed_args.update(
+                        author_name=args[0],
+                )
+        else:
+            await util.edit_embed(
+                self.response_msg,
+                "Invalid arguments!",
+                ""
+            )
+            return
+
+        if arg_count > 1:
+            if isinstance(args[1], (tuple, list)):
+                if len(args[1]) == 3:
+                    util_send_embed_args.update(
+                        title=args[1][0],
+                        url=args[1][1],
+                        thumbnail_url=args[1][2],
+                    )
+
+                elif len(args[1]) == 2:
+                    util_send_embed_args.update(
+                        title=args[1][0],
+                        url=args[1][1],
+                    )
+
+                elif len(args[1]) == 1:
+                    util_send_embed_args.update(
+                        title=args[1][0],
+                    )
+            
+            else:
+                util_send_embed_args.update(
+                    title=args[1],
+                )
+
+        if arg_count > 2:
+            if isinstance(args[2], (tuple, list)):
+                if len(args[2]) == 2:
+                    util_send_embed_args.update(
+                        description=args[2][0],
+                        image_url=args[2][1],
+                    )
+
+                elif len(args[2]) == 1:
+                    util_send_embed_args.update(
+                        description=args[2][0],
+                    )
+            
+            else:
+                util_send_embed_args.update(
+                    description=args[2],
+                )
+
+        if arg_count > 3:
+            util_send_embed_args.update(
+                color=args[3],
+            )
+        
+        
+        if arg_count > 4:
+            util_send_embed_args.update(
+                fields=util.get_embed_fields(args[4])
+            )
+
+        if arg_count > 5:
+            if isinstance(args[5], (tuple, list)):
+                if len(args[5]) == 2:
+                    util_send_embed_args.update(
+                        footer_text=args[5][0],
+                        footer_icon_url=args[5][1],
+                    )
+
+                elif len(args[5]) == 1:
+                    util_send_embed_args.update(
+                        footer_text=args[5][0],
+                    )
+            
+            else:
+                util_send_embed_args.update(
+                    footer_text=args[5],
+                )
+        
+        if arg_count > 6:
+            util_send_embed_args.update(timestamp=args[6])
+        
+        await util.send_embed_2(self.invoke_msg.channel, **util_send_embed_args)
+        await self.response_msg.delete()
+        await self.invoke_msg.delete()
+
+
+    async def cmd_emsudo_edit_2(self):
+        """
+        Implement pg!emsudo_edit_2, for admins to edit embeds sent via the bot
+        """
+
+        util_edit_embed_args = dict(
+            embed_type="rich", author_name=EmptyEmbed, author_name_url=EmptyEmbed, author_icon_url=EmptyEmbed,
+            title=EmptyEmbed, url=EmptyEmbed, thumbnail_url=EmptyEmbed, description=EmptyEmbed, image_url=EmptyEmbed,
+            color=0xFFFFAA, fields=(), footer_text=EmptyEmbed, footer_icon_url=EmptyEmbed, timestamp=None
+        )
+
+        args = eval(self.string)
+
+        edit_msg = await self.invoke_msg.channel.fetch_message(
+            args[0]
+        )
+
+        args = args[1:]
+        arg_count = len(args)
+
+        if arg_count > 0:
+            if isinstance(args[0], (tuple, list)):
+                if len(args[0]) == 3:
+                    util_edit_embed_args.update(
+                        author_name=args[0][0],
+                        author_name_url=args[0][1],
+                        author_icon_url=args[0][2],
+                    )
+                elif len(args[0]) == 2:
+                    util_edit_embed_args.update(
+                        author_name=args[0][0],
+                        author_name_url=args[0][1],
+                    )
+                elif len(args[0]) == 1:
+                    util_edit_embed_args.update(
+                        author_name=args[0][0],
+                    )
+
+            elif isinstance(args[0], dict):
+                await util.edit_embed_from_dict(edit_msg, args[0])
+                await self.response_msg.delete()
+                await self.invoke_msg.delete()
+                return
+
+            else:
+                util_edit_embed_args.update(
+                        author_name=args[0],
+                )
+        else:
+            await util.edit_embed(
+                self.response_msg,
+                "Invalid arguments!",
+                ""
+            )
+            return
+
+        if arg_count > 1:
+            if isinstance(args[1], (tuple, list)):
+                if len(args[1]) == 3:
+                    util_edit_embed_args.update(
+                        title=args[1][0],
+                        url=args[1][1],
+                        thumbnail_url=args[1][2],
+                    )
+
+                elif len(args[1]) == 2:
+                    util_edit_embed_args.update(
+                        title=args[1][0],
+                        url=args[1][1],
+                    )
+
+                elif len(args[1]) == 1:
+                    util_edit_embed_args.update(
+                        title=args[1][0],
+                    )
+            
+            else:
+                util_edit_embed_args.update(
+                    title=args[1],
+                )
+
+        if arg_count > 2:
+            if isinstance(args[2], (tuple, list)):
+                if len(args[2]) == 2:
+                    util_edit_embed_args.update(
+                        description=args[2][0],
+                        image_url=args[2][1],
+                    )
+
+                elif len(args[2]) == 1:
+                    util_edit_embed_args.update(
+                        description=args[2][0],
+                    )
+            
+            else:
+                util_edit_embed_args.update(
+                    description=args[2],
+                )
+
+        if arg_count > 3:
+            util_edit_embed_args.update(
+                color=args[3],
+            )
+        
+        
+        if arg_count > 4:
+            util_edit_embed_args.update(
+                fields=args[4]
+            )
+
+        if arg_count > 5:
+            if isinstance(args[5], (tuple, list)):
+                if len(args[5]) == 2:
+                    util_edit_embed_args.update(
+                        footer_text=args[5][0],
+                        footer_icon_url=args[5][1],
+                    )
+
+                elif len(args[5]) == 1:
+                    util_edit_embed_args.update(
+                        footer_text=args[5][0],
+                    )
+            
+            else:
+                util_edit_embed_args.update(
+                    footer_text=args[5],
+                )
+
+        if arg_count > 6:
+            util_send_embed_args.update(timestamp=args[6])
+        
+        await util.edit_embed_2(edit_msg, **util_edit_embed_args)
         await self.response_msg.delete()
         await self.invoke_msg.delete()
 

--- a/pgbot/common.py
+++ b/pgbot/common.py
@@ -34,7 +34,7 @@ BONCC_THRESHOLD = 10
 BONCC_PARDON = 3
 
 # Constants
-VERSION = "1.3"
+VERSION = "1.3.1"
 TOKEN = os.environ["TOKEN"]
 PREFIX = "pg!"
 

--- a/pgbot/util.py
+++ b/pgbot/util.py
@@ -294,26 +294,3 @@ async def format_archive_messages(messages):
         await asyncio.sleep(0.01)  # Lets the bot do other things
 
     return formatted_msgs
-
-emded_dict_syntax = {
-    'title': 'TITLE',
-    'url': 'URL',
-    'description': 'DESCRIPTION',
-    'type': 'rich',
-    'color': 0,
-    'fields': [
-        {'inline': True,
-        'name': 'title',
-        'value': 'desc'
-        }
-    ],
-    'author': {
-        'name': 'AUTHOR_NAME',
-        'url': 'AUTHOR_URL',
-        'icon_url': 'AUTHOR_ICON'
-    },
-    'image': {
-        'url': 'IMAGE_URL'
-    },
-    'footer': {'icon_url': 'FOOTER_IMG'}
-}

--- a/pgbot/util.py
+++ b/pgbot/util.py
@@ -1,8 +1,9 @@
 import asyncio
-import re
-
 import discord
-
+import re
+import datetime as dt
+from datetime import datetime
+from discord.embeds import EmptyEmbed
 from . import common
 
 
@@ -10,7 +11,7 @@ def format_time(seconds: float, decimal_places: int = 4):
     """
     Formats time with a prefix
     """
-    for fractions, unit in [
+    for fractions, unit in (
         (1.0, "s"),
         (1e-03, "ms"),
         (1e-06, "\u03bcs"),
@@ -20,7 +21,7 @@ def format_time(seconds: float, decimal_places: int = 4):
         (1e-18, "as"),
         (1e-21, "zs"),
         (1e-24, "ys"),
-    ]:
+    ):
         if seconds >= fractions:
             return f"{seconds / fractions:.0{decimal_places}f} {unit}"
     return f"very fast"
@@ -94,7 +95,7 @@ def filter_id(mention: str):
 
 def get_embed_fields(messages):
     # syntax: <Field|Title|desc.[|inline=False]>
-    field_regex = r"(<Field\|.*\|.*(\|True|\|False|)>)"
+    field_regex = r"(<\|.*\|.*(\|True|\|False|)>)"
     field_datas = []
 
     for message in messages:
@@ -144,6 +145,83 @@ async def send_embed(channel, title, description, color=0xFFFFAA, url_image=None
     return await channel.send(embed=embed)
 
 
+async def send_embed_2(
+    channel, embed_type="rich", author_name=EmptyEmbed, author_name_url=EmptyEmbed, author_icon_url=EmptyEmbed, title=EmptyEmbed, url=EmptyEmbed, thumbnail_url=EmptyEmbed,
+    description=EmptyEmbed, image_url=EmptyEmbed, color=0xFFFFAA, fields=[], footer_text=EmptyEmbed, footer_icon_url=EmptyEmbed, timestamp=EmptyEmbed
+    ):
+    """
+    Sends an embed with a much more tight function
+    """
+
+    embed = discord.Embed(title=title, type=embed_type, url=url, description=description, color=color)
+
+    if timestamp:
+        if isinstance(timestamp, str):
+            embed.timestamp = datetime.fromisoformat(timestamp)
+        else:
+            embed.timestamp = timestamp
+
+    if author_name:
+        embed.set_author(name=author_name, url=author_name_url, icon_url=author_icon_url)
+
+    if thumbnail_url:
+        embed.set_thumbnail(url=thumbnail_url)
+    
+    if image_url:
+        embed.set_image(url=image_url)
+
+    for field in fields:
+        embed.add_field(name=field[0], value=field[1], inline=field[2])
+
+    embed.set_footer(text=footer_text, icon_url=footer_icon_url)
+
+    return await channel.send(embed=embed)
+
+
+async def edit_embed_2(
+    message, embed_type="rich", author_name=EmptyEmbed, author_name_url=EmptyEmbed, author_icon_url=EmptyEmbed, title=EmptyEmbed, url=EmptyEmbed, thumbnail_url=EmptyEmbed,
+    description=EmptyEmbed, image_url=EmptyEmbed, color=0xFFFFAA, fields=[], footer_text=EmptyEmbed, footer_icon_url=EmptyEmbed, timestamp=EmptyEmbed
+    ):
+    """
+    Edits the embed of a message with a much more tight function
+    """
+
+    embed = discord.Embed(title=title, type=embed_type, url=url, description=description, color=color)
+
+    if timestamp:
+        if isinstance(timestamp, str):
+            embed.timestamp = datetime.fromisoformat(timestamp)
+        else:
+            embed.timestamp = timestamp
+
+    if author_name:
+        embed.set_author(name=author_name, url=author_name_url, icon_url=author_icon_url)
+
+    if thumbnail_url:
+        embed.set_thumbnail(url=thumbnail_url)
+    
+    if image_url:
+        embed.set_image(url=image_url)
+
+    for field in fields:
+        embed.add_field(name=field[0], value=field[1], inline=field[2])
+
+    embed.set_footer(text=footer_text, icon_url=footer_icon_url)
+
+    return await message.edit(embed=embed)
+
+async def send_embed_from_dict(channel, data):
+    """
+    Sends an embed from a dictionary with a much more tight function
+    """
+    return await channel.send(embed=discord.Embed.from_dict(data))
+
+async def edit_embed_from_dict(message, data):
+    """
+    Edits the embed of a message from a dictionary with a much more tight function
+    """
+    return await message.edit(embed=discord.Embed.from_dict(data))
+
 def format_entries_message(message, entry_type):
     title = f"New {entry_type.lower()} in #{common.ZERO_SPACE}{common.entry_channels[entry_type].name}"
     fields = []
@@ -154,7 +232,7 @@ def format_entries_message(message, entry_type):
     attachments = ""
     if message.attachments:
         for i, attachment in enumerate(message.attachments):
-            attachments += f" - [Link {i+1}]({attachment.url})\n"
+            attachments += f" • [Link {i+1}]({attachment.url})\n"
     else:
         attachments = "No attachments"
 
@@ -216,3 +294,26 @@ async def format_archive_messages(messages):
         await asyncio.sleep(0.01)  # Lets the bot do other things
 
     return formatted_msgs
+
+emded_dict_syntax = {
+    'title': 'TITLE',
+    'url': 'URL',
+    'description': 'DESCRIPTION',
+    'type': 'rich',
+    'color': 0,
+    'fields': [
+        {'inline': True,
+        'name': 'title',
+        'value': 'desc'
+        }
+    ],
+    'author': {
+        'name': 'AUTHOR_NAME',
+        'url': 'AUTHOR_URL',
+        'icon_url': 'AUTHOR_ICON'
+    },
+    'image': {
+        'url': 'IMAGE_URL'
+    },
+    'footer': {'icon_url': 'FOOTER_IMG'}
+}


### PR DESCRIPTION
Added `pg!emsudo_2` and `pg!emsudo_edit_2`, which take in a condensed, tuple based syntax, as well as a dictionary matching the official [Discord docs](https://discord.com/developers/docs/resources/channel#embed-object). In the next major update (or earlier), their features can be passed on to their predecessors `pg!emsudo` and `pg!emsudo_edit`.