### PR TITLE
Fix unrecognized command due to Newline character (\n).

### DIFF
--- a/pgbot/commands/base.py
+++ b/pgbot/commands/base.py
@@ -309,7 +309,7 @@ class OldBaseCommand:
         Must return True on successful command execution, False otherwise
         """
         self.args = self.cmd_str.split()
-        cmd = self.args.pop(0) if self.args else ""
+        cmd = self.args.pop(0).rstrip("\n") if self.args else ""
         self.string = self.cmd_str[len(cmd):].strip()
 
         title = "Unrecognized command!"

--- a/pgbot/commands/base.py
+++ b/pgbot/commands/base.py
@@ -4,6 +4,7 @@ import inspect
 import os
 import platform
 import sys
+import re
 import traceback
 
 import discord
@@ -309,7 +310,7 @@ class OldBaseCommand:
         Must return True on successful command execution, False otherwise
         """
         self.args = self.cmd_str.split()
-        cmd = self.args.pop(0).rstrip("\n") if self.args else ""
+        cmd = re.sub(r'\s'. '', self.args.pop(0)) if self.args else ""
         self.string = self.cmd_str[len(cmd):].strip()
 
         title = "Unrecognized command!"


### PR DESCRIPTION
### Encountered a bug with `pg!exec` command, by using it in the following manner :

```
pg!exec
```py
# Code Here```
```
***
**The following PR should fix it as it removees the newline character before parsing the command**