### PR TITLE
Dad jokes fixes and removed `common.ADMIN_USERS`

### DIFF
--- a/main.py
+++ b/main.py
@@ -126,7 +126,7 @@ async def on_message(msg: discord.Message):
 
         emotion.update("bored", -15)
 
-    elif common.TEST_MODE:
+    elif not common.TEST_MODE:
         await emotion.check_bonk(msg)
 
         # Check for these specific messages, do not try to generalise, because we do not

--- a/main.py
+++ b/main.py
@@ -126,7 +126,7 @@ async def on_message(msg: discord.Message):
 
         emotion.update("bored", -15)
 
-    elif not common.TEST_MODE:
+    elif common.TEST_MODE:
         no_mentions = discord.AllowedMentions.none()
         await emotion.check_bonk(msg)
 
@@ -162,16 +162,29 @@ async def on_message(msg: discord.Message):
             prob += 1
 
             lowered = unidecode.unidecode(msg.content.lower())
-            if "i am" in lowered and len(lowered) < 60:
+            if (" i am " in lowered or lowered.startswith("i am ")) and len(lowered) < 60:
                 # snek is a special case, he loves dad jokes so he will get em
                 # everytime
                 if msg.author.id != 683852333293109269 and random.randint(0, prob):
                     return
 
-                name = msg.content[lowered.index("i am") + 4 :].strip()
-                await msg.channel.send(
-                    f"Hi {name}! I am <@!{common.BOT_ID}>", allowed_mentions=no_mentions
-                )
+                name = msg.content[lowered.index("i am") + 4:].strip()
+                if name:
+                    await msg.channel.send(
+                        f"Hi {name}! I am <@!{common.BOT_ID}>", allowed_mentions=no_mentions
+                    )
+                elif random.random() < 0.1 or msg.author.id == 691691416799150152:
+                    await msg.channel.send(
+                        """To be, or not to be, that is the question:
+Whether 'tis nobler in the mind to suffer
+The slings and arrows of outrageous fortune,
+Or to take arms against a sea of troubles
+And by opposing end them. To die—to sleep,
+No more; and by a sleep to say we end
+The heart-ache and the thousand natural shocks
+That flesh is heir to: 'tis a consummation
+Devoutly to be wish'd. To die, to sleep..."""
+                        )
 
 
 @common.bot.event

--- a/main.py
+++ b/main.py
@@ -127,11 +127,11 @@ async def on_message(msg: discord.Message):
         emotion.update("bored", -15)
 
     elif common.TEST_MODE:
-        no_mentions = discord.AllowedMentions.none()
         await emotion.check_bonk(msg)
 
         # Check for these specific messages, do not try to generalise, because we do not
-        # want the bot spamming the dario quote
+        # want the bot spamming the bydariogamer quote
+        # no_mentions = discord.AllowedMentions.none()
         # if unidecode.unidecode(msg.content.lower()) in common.DEAD_CHAT_TRIGGERS:
         #     # ded chat makes snek sad
         #     await msg.channel.send(
@@ -154,39 +154,12 @@ async def on_message(msg: discord.Message):
             )
         else:
             happy = emotion.get("happy")
-            if happy < -60:
+            if happy < -50:
                 # snek sad, no dad jokes
                 return
 
-            prob = 8 if happy <= 20 else (100 - happy) // 10
-            prob += 1
-
-            lowered = unidecode.unidecode(msg.content.lower().strip())
-            if (" i am " in lowered or lowered.startswith("i am ") or lowered == "i am") and len(lowered) < 60:
-                print(lowered)
-                # snek is a special case, he loves dad jokes so he will get em
-                # everytime
-                if msg.author.id != 683852333293109269 and random.randint(0, prob):
-                    pass    # return
-
-                name = msg.content[lowered.index("i am") + 4:].strip()
-                if name:
-                    await msg.channel.send(
-                        f"Hi {name}! I am <@!{common.BOT_ID}>", allowed_mentions=no_mentions
-                    )
-                elif lowered == 'i am':
-                    print('shakespeare')
-                    await msg.channel.send(
-                        """To be, or not to be, that is the question:
-Whether 'tis nobler in the mind to suffer
-The slings and arrows of outrageous fortune,
-Or to take arms against a sea of troubles
-And by opposing end them. To die—to sleep,
-No more; and by a sleep to say we end
-The heart-ache and the thousand natural shocks
-That flesh is heir to: 'tis a consummation
-Devoutly to be wish'd. To die, to sleep..."""
-                        )
+            if random.random() < (happy+100)/2.0 or msg.author.id == 683852333293109269:
+                await emotion.dad_joke(msg)
 
 
 @common.bot.event

--- a/main.py
+++ b/main.py
@@ -153,11 +153,7 @@ async def on_message(msg: discord.Message):
                 common.entries_discussion_channel, title, "", color, fields=fields
             )
         else:
-            happy = emotion.get("happy")
-            if happy < -50:     # snek sad, no dad jokes
-                return
-
-            if random.random() < (happy+100)/200 or msg.author.id == 683852333293109269:
+            if random.random() < emotion.get("happy")/200 or msg.author.id == 683852333293109269:
                 await emotion.dad_joke(msg)
 
 

--- a/main.py
+++ b/main.py
@@ -161,19 +161,21 @@ async def on_message(msg: discord.Message):
             prob = 8 if happy <= 20 else (100 - happy) // 10
             prob += 1
 
-            lowered = unidecode.unidecode(msg.content.lower())
-            if (" i am " in lowered or lowered.startswith("i am ")) and len(lowered) < 60:
+            lowered = unidecode.unidecode(msg.content.lower().strip())
+            if (" i am " in lowered or lowered.startswith("i am ") or lowered == "i am") and len(lowered) < 60:
+                print(lowered)
                 # snek is a special case, he loves dad jokes so he will get em
                 # everytime
                 if msg.author.id != 683852333293109269 and random.randint(0, prob):
-                    return
+                    pass    # return
 
                 name = msg.content[lowered.index("i am") + 4:].strip()
                 if name:
                     await msg.channel.send(
                         f"Hi {name}! I am <@!{common.BOT_ID}>", allowed_mentions=no_mentions
                     )
-                elif random.random() < 0.1 or msg.author.id == 691691416799150152:
+                elif lowered == 'i am':
+                    print('shakespeare')
                     await msg.channel.send(
                         """To be, or not to be, that is the question:
 Whether 'tis nobler in the mind to suffer

--- a/main.py
+++ b/main.py
@@ -161,7 +161,7 @@ async def on_message(msg: discord.Message):
             prob = 8 if happy <= 20 else (100 - happy) // 10
             prob += 1
 
-            lowered = msg.content.lower()
+            lowered = unidecode.unidecode(msg.content.lower())
             if "i am" in lowered and len(lowered) < 60:
                 # snek is a special case, he loves dad jokes so he will get em
                 # everytime

--- a/main.py
+++ b/main.py
@@ -154,11 +154,10 @@ async def on_message(msg: discord.Message):
             )
         else:
             happy = emotion.get("happy")
-            if happy < -50:
-                # snek sad, no dad jokes
+            if happy < -50:     # snek sad, no dad jokes
                 return
 
-            if random.random() < (happy+100)/2.0 or msg.author.id == 683852333293109269:
+            if random.random() < (happy+100)/200 or msg.author.id == 683852333293109269:
                 await emotion.dad_joke(msg)
 
 

--- a/main.py
+++ b/main.py
@@ -152,9 +152,8 @@ async def on_message(msg: discord.Message):
             await embed_utils.send(
                 common.entries_discussion_channel, title, "", color, fields=fields
             )
-        else:
-            if random.random() < emotion.get("happy")/200 or msg.author.id == 683852333293109269:
-                await emotion.dad_joke(msg)
+        elif random.random() < emotion.get("happy")/200 or msg.author.id == 683852333293109269:
+            await emotion.dad_joke(msg)
 
 
 @common.bot.event

--- a/pgbot/commands/__init__.py
+++ b/pgbot/commands/__init__.py
@@ -20,8 +20,6 @@ def get_perms(mem: discord.Member):
     """
     Return a tuple (is_admin, is_priv) for a given user
     """
-    if mem.id in common.ADMIN_USERS:
-        return True, True
 
     is_priv = False
     for role in mem.roles:

--- a/pgbot/common.py
+++ b/pgbot/common.py
@@ -248,3 +248,16 @@ BYDARIO_QUOTE = """
 > I know because I am dead and noone comes to visit me
 <@!691691416799150152>
 """
+
+SHAKESPEARE_QUOTE = """
+To be, or not to be, that is the question:
+Whether 'tis nobler in the mind to suffer
+The slings and arrows of outrageous fortune,
+Or to take arms against a sea of troubles
+And by opposing end them. To die—to sleep,
+No more; and by a sleep to say we end
+The heart-ache and the thousand natural shocks
+That flesh is heir to: 'tis a consummation
+Devoutly to be wish'd. To die, to sleep...
+\\@ Shakespeare
+"""

--- a/pgbot/common.py
+++ b/pgbot/common.py
@@ -83,14 +83,6 @@ ADMIN_ROLES = {
     841338117968756766,
 }
 
-# AvaxarXapaxa, BaconInvader, MegaJC, Ankith
-ADMIN_USERS = {
-    414330602930700288,
-    265154376409153537,
-    444116866944991236,
-    763015391710281729,
-}
-
 # Specialties, Helpfulies, Verified pygame contributors, Server Boosters
 PRIV_ROLES = {
     774473681325785098,

--- a/pgbot/emotion.py
+++ b/pgbot/emotion.py
@@ -7,6 +7,7 @@ This file defines some utitities and functions for the bots emotion system
 """
 
 import discord
+import unidecode
 
 from . import common, db, embed_utils
 
@@ -65,3 +66,15 @@ async def check_bonk(msg: discord.Message):
 
     update("anger", bonks)
     update("happy", -bonks)
+
+
+async def dad_joke(msg: discord.Message):
+    lowered = unidecode.unidecode(msg.content.lower().strip())
+    if (" i am " in lowered or lowered.startswith("i am ") or lowered == "i am") and len(lowered) < 60:
+        name = msg.content[lowered.index("i am") + 4:].strip()
+        if name:
+            await msg.channel.send(
+                f"Hi {name}! I am <@!{common.BOT_ID}>", allowed_mentions=discord.AllowedMentions.none()
+            )
+        elif lowered == 'i am':
+            await msg.channel.send(common.SHAKESPEARE_QUOTE)

--- a/pgbot/emotion.py
+++ b/pgbot/emotion.py
@@ -71,7 +71,7 @@ async def check_bonk(msg: discord.Message):
 async def dad_joke(msg: discord.Message):
     lowered = unidecode.unidecode(msg.content.lower().strip())
     if (" i am " in lowered or lowered.startswith("i am ") or lowered == "i am") and len(lowered) < 60:
-        name = msg.content[lowered.index("i am") + 4:].strip()
+        name = msg.content[msg.content.lower()("i am") + 4:].strip()
         if name:
             await msg.channel.send(
                 f"Hi {name}! I am <@!{common.BOT_ID}>", allowed_mentions=discord.AllowedMentions.none()


### PR DESCRIPTION
Now the bot ignores casual constructions with the letter sequence `i am` in the middle and reacts in a different way for 'I am' messages without name.
The dad_joke function was moved to emotion.py
Removed ADMIN_USERS from common.py