### PR TITLE
Delete discussion embed when entry is deleted

### DIFF
--- a/pgbot/__init__.py
+++ b/pgbot/__init__.py
@@ -16,7 +16,6 @@ import sys
 import io
 
 import discord
-from discord.embeds import Embed
 import pygame
 
 from pgbot import commands, common, db, emotion, routine
@@ -98,7 +97,10 @@ def format_entries_message(msg: discord.Message, entry_type: str):
     """
     Formats an entries message to be reposted in discussion channel
     """
-    title = f"New {entry_type.lower()} in #{common.ZERO_SPACE}{common.entry_channels[entry_type].name}"
+    if entry_type != "":
+        title = f"New {entry_type.lower()} in #{common.ZERO_SPACE}{common.entry_channels[entry_type].name}"
+    else:
+        title=""
 
     attachments = ""
     if msg.attachments:
@@ -181,14 +183,17 @@ async def message_delete(msg: discord.Message):
 
     if msg.channel in common.entry_channels.values():
         history = await common.entries_discussion_channel.history(
-            around=msg.created_at
+            around=msg.created_at,
+            limit=5
         ).flatten()
+        print(history[0].content)
         message: discord.Message
         for message in history:
             embed: discord.embeds.Embed = message.embeds[0]
             link = embed.fields[1].value
             if int(link.split("/")[6][:-1]) == msg.id:
                 await message.delete()
+                break
 
 
 async def message_edit(old: discord.Message, new: discord.Message):
@@ -201,6 +206,23 @@ async def message_edit(old: discord.Message, new: discord.Message):
                 await commands.handle(new, common.cmd_logs[new.id])
         except discord.HTTPException:
             pass
+    if new.channel in common.entry_channels.values():
+        history = await common.entries_discussion_channel.history(
+            around=old.created_at,
+            limit=5
+        ).flatten()
+        message: discord.Message
+        for message in history:
+            message_embed: discord.embeds.Embed = message.embeds[0]
+            link = message_embed.fields[1].value
+            if int(link.split("/")[6][:-1]) == new.id:
+                title, fields = format_entries_message(new, "")
+                await embed_utils.edit_2(
+                    message, 
+                    embed=message_embed, 
+                    fields=fields
+                    )
+                break
 
 
 async def handle_message(msg: discord.Message):

--- a/pgbot/__init__.py
+++ b/pgbot/__init__.py
@@ -16,6 +16,7 @@ import sys
 import io
 
 import discord
+from discord.embeds import Embed
 import pygame
 
 from pgbot import commands, common, db, emotion, routine
@@ -174,6 +175,20 @@ async def message_delete(msg: discord.Message):
                 if common.cmd_logs[log].id == msg.id:
                     del common.cmd_logs[log]
                     return
+
+    if common.GENERIC:
+        return
+
+    if msg.channel in common.entry_channels.values():
+        history = await common.entries_discussion_channel.history(
+            around=msg.created_at
+        ).flatten()
+        message: discord.Message
+        for message in history:
+            embed: discord.embeds.Embed = message.embeds[0]
+            link = embed.fields[1].value
+            if int(link.split("/")[6][:-1]) == msg.id:
+                await message.delete()
 
 
 async def message_edit(old: discord.Message, new: discord.Message):

--- a/pgbot/__init__.py
+++ b/pgbot/__init__.py
@@ -100,7 +100,7 @@ def format_entries_message(msg: discord.Message, entry_type: str):
     if entry_type != "":
         title = f"New {entry_type.lower()} in #{common.ZERO_SPACE}{common.entry_channels[entry_type].name}"
     else:
-        title = ""
+        title=""
 
     attachments = ""
     if msg.attachments:
@@ -182,12 +182,12 @@ async def message_delete(msg: discord.Message):
         return
 
     if msg.channel in common.entry_channels.values():
-        history = await common.entries_discussion_channel.history(
-            around=msg.created_at, limit=5
-        ).flatten()
-        print(history[0].content)
+        history = common.entries_discussion_channel.history(
+            around=msg.created_at,
+            limit=5
+        )
         message: discord.Message
-        for message in history:
+        async for message in history:
             embed: discord.embeds.Embed = message.embeds[0]
             link = embed.fields[1].value
             if int(link.split("/")[6][:-1]) == msg.id:
@@ -206,16 +206,21 @@ async def message_edit(old: discord.Message, new: discord.Message):
         except discord.HTTPException:
             pass
     if new.channel in common.entry_channels.values():
-        history = await common.entries_discussion_channel.history(
-            around=old.created_at, limit=5
-        ).flatten()
+        history = common.entries_discussion_channel.history(
+            around=old.created_at,
+            limit=5
+        )
         message: discord.Message
-        for message in history:
+        async for message in history:
             message_embed: discord.embeds.Embed = message.embeds[0]
             link = message_embed.fields[1].value
             if int(link.split("/")[6][:-1]) == new.id:
                 title, fields = format_entries_message(new, "")
-                await embed_utils.edit_2(message, embed=message_embed, fields=fields)
+                await embed_utils.edit_2(
+                    message, 
+                    embed=message_embed, 
+                    fields=fields
+                    )
                 break
 
 

--- a/pgbot/__init__.py
+++ b/pgbot/__init__.py
@@ -100,7 +100,7 @@ def format_entries_message(msg: discord.Message, entry_type: str):
     if entry_type != "":
         title = f"New {entry_type.lower()} in #{common.ZERO_SPACE}{common.entry_channels[entry_type].name}"
     else:
-        title=""
+        title = ""
 
     attachments = ""
     if msg.attachments:
@@ -183,8 +183,7 @@ async def message_delete(msg: discord.Message):
 
     if msg.channel in common.entry_channels.values():
         history = await common.entries_discussion_channel.history(
-            around=msg.created_at,
-            limit=5
+            around=msg.created_at, limit=5
         ).flatten()
         print(history[0].content)
         message: discord.Message
@@ -208,8 +207,7 @@ async def message_edit(old: discord.Message, new: discord.Message):
             pass
     if new.channel in common.entry_channels.values():
         history = await common.entries_discussion_channel.history(
-            around=old.created_at,
-            limit=5
+            around=old.created_at, limit=5
         ).flatten()
         message: discord.Message
         for message in history:
@@ -217,11 +215,7 @@ async def message_edit(old: discord.Message, new: discord.Message):
             link = message_embed.fields[1].value
             if int(link.split("/")[6][:-1]) == new.id:
                 title, fields = format_entries_message(new, "")
-                await embed_utils.edit_2(
-                    message, 
-                    embed=message_embed, 
-                    fields=fields
-                    )
+                await embed_utils.edit_2(message, embed=message_embed, fields=fields)
                 break
 
 


### PR DESCRIPTION
Helps in keeping the discussion channel clean when someone accidently sends something in resource or showcase.

Right now it deletes the embed but maybe editing the embed to say the original message has been deleted would've been better.

Also, for some reason, black has added an import statement in line 19. I don't know if its necessary.